### PR TITLE
Use dataset_value when _filepath is None

### DIFF
--- a/kedro_great/kedro_great.py
+++ b/kedro_great/kedro_great.py
@@ -100,7 +100,7 @@ class KedroGreat:
 
             dataset = catalog._get_dataset(dataset_name)
             dataset_path = getattr(dataset, "_filepath", None)
-            df = dataset.load()
+            df = dataset.load() if dataset_path else dataset_value
 
             try:
                 for target_suite_name in target_suite_names:

--- a/kedro_great/kedro_great.py
+++ b/kedro_great/kedro_great.py
@@ -11,7 +11,7 @@ from great_expectations.datasource.types import BatchMarkers
 from great_expectations.validator.validator import Validator
 from great_expectations.exceptions import ConfigNotFoundError
 from kedro.framework.hooks import hook_impl
-from kedro.io import DataCatalog
+from kedro.io import DataCatalog, MemoryDataset
 
 from .exceptions import UnsupportedDataSet, SuiteValidationFailure
 from .data import (
@@ -99,8 +99,7 @@ class KedroGreat:
             )
 
             dataset = catalog._get_dataset(dataset_name)
-            dataset_path = getattr(dataset, "_filepath", None)
-            df = dataset.load() if dataset_path else dataset_value
+            df = dataset_value if isinstance(dataset, MemoryDataset) else dataset.load()
 
             try:
                 for target_suite_name in target_suite_names:


### PR DESCRIPTION
When trying to load `InMemoryDataset` `kedro.io.core.DataSetError: Data for MemoryDataSet has not been saved yet` exception is raised. To prevent that `dataset_value` is used when `_filepath` is `None`